### PR TITLE
Fix missing accent variable in oneliner theme

### DIFF
--- a/GlassFin/GlassFin-oneliner.css
+++ b/GlassFin/GlassFin-oneliner.css
@@ -34,6 +34,7 @@
   --gf-accent-h: 210;
   --gf-accent-s: 100%;
   --gf-accent-l: 60%;
+  --gf-accent: hsl(var(--gf-accent-h) var(--gf-accent-s) var(--gf-accent-l));
   --gf-radius: 14px;
   --gf-border: rgba(255,255,255,.10);
   --gf-glass-blur: 14px;


### PR DESCRIPTION
## Summary
- define `--gf-accent` CSS variable in GlassFin-oneliner theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dd6a8dcc832dbbb6a956a565c93e